### PR TITLE
feat: add prompt input for variant creation

### DIFF
--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -5,3 +5,4 @@ export { Textarea } from "./textarea";
 export { ErrorMessage } from "./error-message";
 export { ImageUpload } from "./image-upload";
 export { PostcardPreview } from "./PostcardPreview";
+export { Modal } from "./modal";

--- a/packages/ui/src/modal.tsx
+++ b/packages/ui/src/modal.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  size = "md",
+}) => {
+  if (!isOpen) return null;
+
+  const sizeClasses = {
+    sm: "max-w-md",
+    md: "max-w-lg",
+    lg: "max-w-2xl",
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        className={`relative bg-white rounded-2xl shadow-2xl p-6 mx-4 w-full ${sizeClasses[size]} max-h-[90vh] overflow-y-auto`}
+      >
+        {title && (
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="Close"
+            >
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #7

## Summary

- Add Modal component to UI library
- Add prompt input when creating variants
- Include 8 AI-generated example prompts for inspiration
- Pass custom prompts to OpenAI for style-specific transformations

When users click "Create Variant", they now see a modal where they can:
1. Enter their own custom style prompt
2. Choose from example prompts like "Make it comic book style" or "Add vibrant neon colors"



Generated with [Claude Code](https://claude.ai/code)