### PR TITLE
feat: Add OpenStreetMap to show photo/video location on designs page

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,6 +23,7 @@
     "@vercel/blob": "^2.0.0",
     "cloudinary": "^2.7.0",
     "exifr": "^7.1.3",
+    "leaflet": "^1.9.4",
     "next": "^15.5.4",
     "next-cloudinary": "^6.16.0",
     "openai": "^5.23.0",
@@ -30,11 +31,13 @@
     "pg": "^8.16.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0",
     "sharp": "^0.34.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
     "@tailwindcss/postcss": "^4",
+    "@types/leaflet": "^1.9.20",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/www/payload-types.ts
+++ b/apps/www/payload-types.ts
@@ -13,53 +13,53 @@
  * via the `definition` "supportedTimezones".
  */
 export type SupportedTimezones =
-  | 'Pacific/Midway'
-  | 'Pacific/Niue'
-  | 'Pacific/Honolulu'
-  | 'Pacific/Rarotonga'
-  | 'America/Anchorage'
-  | 'Pacific/Gambier'
-  | 'America/Los_Angeles'
-  | 'America/Tijuana'
-  | 'America/Denver'
-  | 'America/Phoenix'
-  | 'America/Chicago'
-  | 'America/Guatemala'
-  | 'America/New_York'
-  | 'America/Bogota'
-  | 'America/Caracas'
-  | 'America/Santiago'
-  | 'America/Buenos_Aires'
-  | 'America/Sao_Paulo'
-  | 'Atlantic/South_Georgia'
-  | 'Atlantic/Azores'
-  | 'Atlantic/Cape_Verde'
-  | 'Europe/London'
-  | 'Europe/Berlin'
-  | 'Africa/Lagos'
-  | 'Europe/Athens'
-  | 'Africa/Cairo'
-  | 'Europe/Moscow'
-  | 'Asia/Riyadh'
-  | 'Asia/Dubai'
-  | 'Asia/Baku'
-  | 'Asia/Karachi'
-  | 'Asia/Tashkent'
-  | 'Asia/Calcutta'
-  | 'Asia/Dhaka'
-  | 'Asia/Almaty'
-  | 'Asia/Jakarta'
-  | 'Asia/Bangkok'
-  | 'Asia/Shanghai'
-  | 'Asia/Singapore'
-  | 'Asia/Tokyo'
-  | 'Asia/Seoul'
-  | 'Australia/Brisbane'
-  | 'Australia/Sydney'
-  | 'Pacific/Guam'
-  | 'Pacific/Noumea'
-  | 'Pacific/Auckland'
-  | 'Pacific/Fiji';
+  | "Pacific/Midway"
+  | "Pacific/Niue"
+  | "Pacific/Honolulu"
+  | "Pacific/Rarotonga"
+  | "America/Anchorage"
+  | "Pacific/Gambier"
+  | "America/Los_Angeles"
+  | "America/Tijuana"
+  | "America/Denver"
+  | "America/Phoenix"
+  | "America/Chicago"
+  | "America/Guatemala"
+  | "America/New_York"
+  | "America/Bogota"
+  | "America/Caracas"
+  | "America/Santiago"
+  | "America/Buenos_Aires"
+  | "America/Sao_Paulo"
+  | "Atlantic/South_Georgia"
+  | "Atlantic/Azores"
+  | "Atlantic/Cape_Verde"
+  | "Europe/London"
+  | "Europe/Berlin"
+  | "Africa/Lagos"
+  | "Europe/Athens"
+  | "Africa/Cairo"
+  | "Europe/Moscow"
+  | "Asia/Riyadh"
+  | "Asia/Dubai"
+  | "Asia/Baku"
+  | "Asia/Karachi"
+  | "Asia/Tashkent"
+  | "Asia/Calcutta"
+  | "Asia/Dhaka"
+  | "Asia/Almaty"
+  | "Asia/Jakarta"
+  | "Asia/Bangkok"
+  | "Asia/Shanghai"
+  | "Asia/Singapore"
+  | "Asia/Tokyo"
+  | "Asia/Seoul"
+  | "Australia/Brisbane"
+  | "Australia/Sydney"
+  | "Pacific/Guam"
+  | "Pacific/Noumea"
+  | "Pacific/Auckland"
+  | "Pacific/Fiji";
 
 export interface Config {
   auth: {
@@ -67,25 +67,33 @@ export interface Config {
   };
   blocks: {};
   collections: {
-    'postcard-designs': PostcardDesign;
+    "postcard-designs": PostcardDesign;
     users: User;
     postcards: Postcard;
     media: Media;
     templates: Template;
-    'payload-locked-documents': PayloadLockedDocument;
-    'payload-preferences': PayloadPreference;
-    'payload-migrations': PayloadMigration;
+    "payload-locked-documents": PayloadLockedDocument;
+    "payload-preferences": PayloadPreference;
+    "payload-migrations": PayloadMigration;
   };
   collectionsJoins: {};
   collectionsSelect: {
-    'postcard-designs': PostcardDesignsSelect<false> | PostcardDesignsSelect<true>;
+    "postcard-designs":
+      | PostcardDesignsSelect<false>
+      | PostcardDesignsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     postcards: PostcardsSelect<false> | PostcardsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     templates: TemplatesSelect<false> | TemplatesSelect<true>;
-    'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
-    'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
-    'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
+    "payload-locked-documents":
+      | PayloadLockedDocumentsSelect<false>
+      | PayloadLockedDocumentsSelect<true>;
+    "payload-preferences":
+      | PayloadPreferencesSelect<false>
+      | PayloadPreferencesSelect<true>;
+    "payload-migrations":
+      | PayloadMigrationsSelect<false>
+      | PayloadMigrationsSelect<true>;
   };
   db: {
     defaultIDType: number;
@@ -94,7 +102,7 @@ export interface Config {
   globalsSelect: {};
   locale: null;
   user: User & {
-    collection: 'users';
+    collection: "users";
   };
   jobs: {
     tasks: unknown;
@@ -157,8 +165,10 @@ export interface PostcardDesign {
   videoUrl?: string | null;
   backgroundColor?: string | null;
   textColor?: string | null;
-  font?: ('sans' | 'serif' | 'handwritten' | 'decorative') | null;
-  layout?: ('full-image' | 'split-horizontal' | 'split-vertical' | 'border-frame') | null;
+  font?: ("sans" | "serif" | "handwritten" | "decorative") | null;
+  layout?:
+    | ("full-image" | "split-horizontal" | "split-vertical" | "border-frame")
+    | null;
   defaultMessage?: string | null;
   /**
    * Text overlays to display on the postcard
@@ -168,7 +178,7 @@ export interface PostcardDesign {
         id: string;
         text: string;
         fontSize?: number | null;
-        fontFamily?: ('sans-serif' | 'serif' | 'cursive' | 'display') | null;
+        fontFamily?: ("sans-serif" | "serif" | "cursive" | "display") | null;
         color?: string | null;
         strokeColor?: string | null;
         strokeWidth?: number | null;
@@ -185,10 +195,12 @@ export interface PostcardDesign {
          */
         rotation?: number | null;
         opacity?: number | null;
-        textAlign?: ('left' | 'center' | 'right') | null;
+        textAlign?: ("left" | "center" | "right") | null;
       }[]
     | null;
-  category?: ('holiday' | 'birthday' | 'thankyou' | 'greeting' | 'travel' | 'custom') | null;
+  category?:
+    | ("holiday" | "birthday" | "thankyou" | "greeting" | "travel" | "custom")
+    | null;
   isPublic?: boolean | null;
   createdBy?: (number | null) | User;
   updatedAt: string;
@@ -219,7 +231,7 @@ export interface Media {
  */
 export interface User {
   id: number;
-  role: 'admin' | 'user';
+  role: "admin" | "user";
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -253,8 +265,8 @@ export interface Postcard {
         version: number;
         [k: string]: unknown;
       }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      direction: ("ltr" | "rtl") | null;
+      format: "left" | "start" | "center" | "right" | "end" | "justify" | "";
       indent: number;
       version: number;
     };
@@ -264,7 +276,7 @@ export interface Postcard {
   recipientAddress: string;
   senderName: string;
   image: number | Media;
-  status?: ('draft' | 'sent' | 'delivered') | null;
+  status?: ("draft" | "sent" | "delivered") | null;
   aiGenerated?: boolean | null;
   createdBy: number | User;
   updatedAt: string;
@@ -278,7 +290,9 @@ export interface Template {
   id: number;
   name: string;
   description?: string | null;
-  category?: ('holiday' | 'birthday' | 'thankyou' | 'greeting' | 'travel') | null;
+  category?:
+    | ("holiday" | "birthday" | "thankyou" | "greeting" | "travel")
+    | null;
   templateImage?: (number | null) | Media;
   defaultMessage?: {
     root: {
@@ -288,8 +302,8 @@ export interface Template {
         version: number;
         [k: string]: unknown;
       }[];
-      direction: ('ltr' | 'rtl') | null;
-      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      direction: ("ltr" | "rtl") | null;
+      format: "left" | "start" | "center" | "right" | "end" | "justify" | "";
       indent: number;
       version: number;
     };
@@ -307,28 +321,28 @@ export interface PayloadLockedDocument {
   id: number;
   document?:
     | ({
-        relationTo: 'postcard-designs';
+        relationTo: "postcard-designs";
         value: number | PostcardDesign;
       } | null)
     | ({
-        relationTo: 'users';
+        relationTo: "users";
         value: number | User;
       } | null)
     | ({
-        relationTo: 'postcards';
+        relationTo: "postcards";
         value: number | Postcard;
       } | null)
     | ({
-        relationTo: 'media';
+        relationTo: "media";
         value: number | Media;
       } | null)
     | ({
-        relationTo: 'templates';
+        relationTo: "templates";
         value: number | Template;
       } | null);
   globalSlug?: string | null;
   user: {
-    relationTo: 'users';
+    relationTo: "users";
     value: number | User;
   };
   updatedAt: string;
@@ -341,7 +355,7 @@ export interface PayloadLockedDocument {
 export interface PayloadPreference {
   id: number;
   user: {
-    relationTo: 'users';
+    relationTo: "users";
     value: number | User;
   };
   key?: string | null;
@@ -521,7 +535,6 @@ export interface Auth {
   [k: string]: unknown;
 }
 
-
-declare module 'payload' {
+declare module "payload" {
   export interface GeneratedTypes extends Config {}
 }

--- a/apps/www/src/app/actions/upload.ts
+++ b/apps/www/src/app/actions/upload.ts
@@ -44,7 +44,7 @@ export async function uploadImage(formData: FormData): Promise<any> {
       // Download the thumbnail from Cloudinary to store in Payload
       const thumbnailResponse = await fetch(cloudinaryResult.thumbnailUrl);
       const thumbnailBuffer = Buffer.from(
-        await thumbnailResponse.arrayBuffer()
+        await thumbnailResponse.arrayBuffer(),
       );
 
       // Create media entry with the thumbnail

--- a/apps/www/src/app/designs/[id]/page.tsx
+++ b/apps/www/src/app/designs/[id]/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { getDesignById } from "@/app/actions/designs";
 import { notFound } from "next/navigation";
+
+// Dynamic import for Map component to avoid SSR issues with Leaflet
+const Map = dynamic(() => import("@repo/ui").then((mod) => mod.Map), {
+  ssr: false,
+  loading: () => (
+    <div className="h-[400px] bg-gray-100 rounded-lg flex items-center justify-center">
+      <p className="text-gray-500">Loading map...</p>
+    </div>
+  ),
+});
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -169,6 +180,43 @@ export default function DesignLandingPage({ params }: PageProps) {
                 <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-amber-100 text-amber-800 capitalize">
                   {design.category}
                 </span>
+              </div>
+            )}
+
+            {/* Location Map */}
+            {design.latitude && design.longitude && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="w-5 h-5 text-amber-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                    />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                  <h3 className="text-lg font-semibold text-gray-900">
+                    {design.locationName || "Photo Location"}
+                  </h3>
+                </div>
+                <div className="rounded-xl overflow-hidden shadow-lg border border-gray-200">
+                  <Map
+                    latitude={design.latitude}
+                    longitude={design.longitude}
+                    locationName={design.locationName}
+                    height="400px"
+                  />
+                </div>
               </div>
             )}
 

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -29,12 +29,15 @@ body {
 }
 
 /* Ensure inputs always have proper text color */
-input, textarea, select {
+input,
+textarea,
+select {
   color: #111827; /* gray-900 */
   background-color: white;
 }
 
-input::placeholder, textarea::placeholder {
+input::placeholder,
+textarea::placeholder {
   color: #9ca3af; /* gray-400 */
 }
 

--- a/apps/www/src/lib/image-analysis.ts
+++ b/apps/www/src/lib/image-analysis.ts
@@ -28,7 +28,7 @@ interface ImageAnalysisResult {
  */
 export async function describeImage(
   mediaRef: string | any,
-  authToken: string
+  authToken: string,
 ): Promise<ImageAnalysisResult> {
   // Initialize OpenAI
   const apiKey = process.env.OPENAI_API_KEY;
@@ -70,17 +70,17 @@ export async function describeImage(
         latitude: locationInfo.latitude,
         longitude: locationInfo.longitude,
         locationName: locationInfo.locationName || "No location name available",
-      }
+      },
     );
   } else {
     console.log(
-      `❌ No EXIF coordinates found for ${mediaDoc.filename || "image"}`
+      `❌ No EXIF coordinates found for ${mediaDoc.filename || "image"}`,
     );
   }
 
   // Convert buffer to data URL for OpenAI
   const jpegBuffer = await import("sharp").then((sharp) =>
-    sharp.default(imageBuffer).jpeg({ quality: 90 }).toBuffer()
+    sharp.default(imageBuffer).jpeg({ quality: 90 }).toBuffer(),
   );
   const base64 = jpegBuffer.toString("base64");
   const imageDataUrl = `data:image/jpeg;base64,${base64}`;
@@ -133,7 +133,7 @@ export async function describeImage(
  */
 async function getImageBuffer(
   mediaDoc: any,
-  authToken: string
+  authToken: string,
 ): Promise<Buffer> {
   // Get the URL from the media document
   const urlFromDoc: string | undefined = mediaDoc.url;
@@ -159,7 +159,7 @@ async function getImageBuffer(
 
   if (!res.ok) {
     throw new Error(
-      `Failed to fetch media binary (${res.status} ${res.statusText}) from ${fullUrl}`
+      `Failed to fetch media binary (${res.status} ${res.statusText}) from ${fullUrl}`,
     );
   }
 

--- a/apps/www/src/migrations/20250926_204751.json
+++ b/apps/www/src/migrations/20250926_204751.json
@@ -142,12 +142,8 @@
           "name": "postcard_designs_overlays_parent_id_fk",
           "tableFrom": "postcard_designs_overlays",
           "tableTo": "postcard_designs",
-          "columnsFrom": [
-            "_parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -370,12 +366,8 @@
           "name": "postcard_designs_image_original_id_media_id_fk",
           "tableFrom": "postcard_designs",
           "tableTo": "media",
-          "columnsFrom": [
-            "image_original_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["image_original_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -383,12 +375,8 @@
           "name": "postcard_designs_front_image_id_media_id_fk",
           "tableFrom": "postcard_designs",
           "tableTo": "media",
-          "columnsFrom": [
-            "front_image_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["front_image_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -396,12 +384,8 @@
           "name": "postcard_designs_created_by_id_users_id_fk",
           "tableFrom": "postcard_designs",
           "tableTo": "users",
-          "columnsFrom": [
-            "created_by_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -514,12 +498,8 @@
           "name": "postcard_designs_rels_parent_fk",
           "tableFrom": "postcard_designs_rels",
           "tableTo": "postcard_designs",
-          "columnsFrom": [
-            "parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -527,12 +507,8 @@
           "name": "postcard_designs_rels_media_fk",
           "tableFrom": "postcard_designs_rels",
           "tableTo": "media",
-          "columnsFrom": [
-            "media_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -615,12 +591,8 @@
           "name": "users_sessions_parent_id_fk",
           "tableFrom": "users_sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "_parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -910,12 +882,8 @@
           "name": "postcards_image_id_media_id_fk",
           "tableFrom": "postcards",
           "tableTo": "media",
-          "columnsFrom": [
-            "image_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -923,12 +891,8 @@
           "name": "postcards_created_by_id_users_id_fk",
           "tableFrom": "postcards",
           "tableTo": "users",
-          "columnsFrom": [
-            "created_by_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1193,12 +1157,8 @@
           "name": "templates_template_image_id_media_id_fk",
           "tableFrom": "templates",
           "tableTo": "media",
-          "columnsFrom": [
-            "template_image_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["template_image_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1480,12 +1440,8 @@
           "name": "payload_locked_documents_rels_parent_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "payload_locked_documents",
-          "columnsFrom": [
-            "parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1493,12 +1449,8 @@
           "name": "payload_locked_documents_rels_postcard_designs_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "postcard_designs",
-          "columnsFrom": [
-            "postcard_designs_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["postcard_designs_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1506,12 +1458,8 @@
           "name": "payload_locked_documents_rels_users_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "users",
-          "columnsFrom": [
-            "users_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1519,12 +1467,8 @@
           "name": "payload_locked_documents_rels_postcards_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "postcards",
-          "columnsFrom": [
-            "postcards_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["postcards_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1532,12 +1476,8 @@
           "name": "payload_locked_documents_rels_media_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "media",
-          "columnsFrom": [
-            "media_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1545,12 +1485,8 @@
           "name": "payload_locked_documents_rels_templates_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "templates",
-          "columnsFrom": [
-            "templates_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["templates_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1754,12 +1690,8 @@
           "name": "payload_preferences_rels_parent_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "payload_preferences",
-          "columnsFrom": [
-            "parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1767,12 +1699,8 @@
           "name": "payload_preferences_rels_users_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "users",
-          "columnsFrom": [
-            "users_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1864,31 +1792,17 @@
     "public.enum_postcard_designs_overlays_font_family": {
       "name": "enum_postcard_designs_overlays_font_family",
       "schema": "public",
-      "values": [
-        "sans-serif",
-        "serif",
-        "cursive",
-        "display"
-      ]
+      "values": ["sans-serif", "serif", "cursive", "display"]
     },
     "public.enum_postcard_designs_overlays_text_align": {
       "name": "enum_postcard_designs_overlays_text_align",
       "schema": "public",
-      "values": [
-        "left",
-        "center",
-        "right"
-      ]
+      "values": ["left", "center", "right"]
     },
     "public.enum_postcard_designs_font": {
       "name": "enum_postcard_designs_font",
       "schema": "public",
-      "values": [
-        "sans",
-        "serif",
-        "handwritten",
-        "decorative"
-      ]
+      "values": ["sans", "serif", "handwritten", "decorative"]
     },
     "public.enum_postcard_designs_layout": {
       "name": "enum_postcard_designs_layout",
@@ -1915,30 +1829,17 @@
     "public.enum_users_role": {
       "name": "enum_users_role",
       "schema": "public",
-      "values": [
-        "admin",
-        "user"
-      ]
+      "values": ["admin", "user"]
     },
     "public.enum_postcards_status": {
       "name": "enum_postcards_status",
       "schema": "public",
-      "values": [
-        "draft",
-        "sent",
-        "delivered"
-      ]
+      "values": ["draft", "sent", "delivered"]
     },
     "public.enum_templates_category": {
       "name": "enum_templates_category",
       "schema": "public",
-      "values": [
-        "holiday",
-        "birthday",
-        "thankyou",
-        "greeting",
-        "travel"
-      ]
+      "values": ["holiday", "birthday", "thankyou", "greeting", "travel"]
     }
   },
   "schemas": {},

--- a/apps/www/src/migrations/20250926_204751.ts
+++ b/apps/www/src/migrations/20250926_204751.ts
@@ -1,4 +1,8 @@
-import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-vercel-postgres'
+import {
+  MigrateUpArgs,
+  MigrateDownArgs,
+  sql,
+} from "@payloadcms/db-vercel-postgres";
 
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
@@ -228,10 +232,14 @@ export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   CREATE INDEX "payload_preferences_rels_path_idx" ON "payload_preferences_rels" USING btree ("path");
   CREATE INDEX "payload_preferences_rels_users_id_idx" ON "payload_preferences_rels" USING btree ("users_id");
   CREATE INDEX "payload_migrations_updated_at_idx" ON "payload_migrations" USING btree ("updated_at");
-  CREATE INDEX "payload_migrations_created_at_idx" ON "payload_migrations" USING btree ("created_at");`)
+  CREATE INDEX "payload_migrations_created_at_idx" ON "payload_migrations" USING btree ("created_at");`);
 }
 
-export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+export async function down({
+  db,
+  payload,
+  req,
+}: MigrateDownArgs): Promise<void> {
   await db.execute(sql`
    DROP TABLE "postcard_designs_overlays" CASCADE;
   DROP TABLE "postcard_designs" CASCADE;
@@ -253,5 +261,5 @@ export async function down({ db, payload, req }: MigrateDownArgs): Promise<void>
   DROP TYPE "public"."enum_postcard_designs_category";
   DROP TYPE "public"."enum_users_role";
   DROP TYPE "public"."enum_postcards_status";
-  DROP TYPE "public"."enum_templates_category";`)
+  DROP TYPE "public"."enum_templates_category";`);
 }

--- a/apps/www/src/migrations/index.ts
+++ b/apps/www/src/migrations/index.ts
@@ -1,9 +1,9 @@
-import * as migration_20250926_204751 from './20250926_204751';
+import * as migration_20250926_204751 from "./20250926_204751";
 
 export const migrations = [
   {
     up: migration_20250926_204751.up,
     down: migration_20250926_204751.down,
-    name: '20250926_204751'
+    name: "20250926_204751",
   },
 ];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,11 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
+    "@types/leaflet": "^1.9.20",
     "@types/react": "^19",
     "typescript": "^5"
+  },
+  "dependencies": {
+    "leaflet": "^1.9.4"
   }
 }

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -10,3 +10,4 @@ export { OverlayEditor } from "./OverlayEditor";
 export type { Overlay } from "./OverlayEditor";
 export { Tabs, TabPanel } from "./tabs";
 export type { Tab } from "./tabs";
+export { Map } from "./map";

--- a/packages/ui/src/map.tsx
+++ b/packages/ui/src/map.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useId } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+// Fix for default markers in Leaflet
+// biome-ignore lint/suspicious/noExplicitAny: Leaflet's type definitions are incomplete
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl:
+    "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+  iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+  shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+});
+
+interface LocationMapProps {
+  latitude: number;
+  longitude: number;
+  locationName?: string;
+  height?: string;
+  className?: string;
+}
+
+export function Map({
+  latitude,
+  longitude,
+  locationName,
+  height = "400px",
+  className = "",
+}: LocationMapProps) {
+  const mapId = useId();
+
+  useEffect(() => {
+    // Create map instance
+    const mapInstance = L.map(mapId, {
+      center: [latitude, longitude],
+      zoom: 13,
+      scrollWheelZoom: false,
+    });
+
+    // Add OpenStreetMap tiles
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      maxZoom: 19,
+    }).addTo(mapInstance);
+
+    // Add marker
+    const marker = L.marker([latitude, longitude]).addTo(mapInstance);
+
+    // Add popup if location name is provided
+    if (locationName) {
+      marker.bindPopup(locationName).openPopup();
+    }
+
+    // Cleanup on unmount
+    return () => {
+      mapInstance.remove();
+    };
+  }, [latitude, longitude, locationName, mapId]);
+
+  return (
+    <div
+      id={mapId}
+      className={className}
+      style={{
+        height,
+        width: "100%",
+        borderRadius: "0.5rem",
+        overflow: "hidden",
+      }}
+    />
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       exifr:
         specifier: ^7.1.3
         version: 7.1.3
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       next:
         specifier: ^15.5.4
         version: 15.5.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
@@ -71,6 +74,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-leaflet:
+        specifier: ^5.0.0
+        version: 5.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sharp:
         specifier: ^0.34.3
         version: 0.34.4
@@ -81,6 +87,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.13
+      '@types/leaflet':
+        specifier: ^1.9.20
+        version: 1.9.20
       '@types/node':
         specifier: ^20
         version: 20.19.17
@@ -99,6 +108,9 @@ importers:
 
   packages/ui:
     dependencies:
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       react:
         specifier: ^19
         version: 19.1.0
@@ -106,6 +118,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.0
         version: 2.2.0
+      '@types/leaflet':
+        specifier: ^1.9.20
+        version: 1.9.20
       '@types/react':
         specifier: ^19
         version: 19.1.14
@@ -1161,6 +1176,13 @@ packages:
       react: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
       react-dom: ^19.0.0 || ^19.0.0-rc-65a56d0e-20241020
 
+  '@react-leaflet/core@3.0.0':
+    resolution: {integrity: sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1270,11 +1292,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/leaflet@1.9.20':
+    resolution: {integrity: sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==}
 
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
@@ -1905,6 +1933,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
   lexical@0.35.0:
     resolution: {integrity: sha512-3VuV8xXhh5xJA6tzvfDvE0YBCMkIZUmxtRilJQDDdCgJCc+eut6qAv2qbN+pbqvarqcQqPN1UF+8YvsjmyOZpw==}
 
@@ -2410,6 +2441,13 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-leaflet@5.0.0:
+    resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
 
   react-select@5.9.0:
     resolution: {integrity: sha512-nwRKGanVHGjdccsnzhFte/PULziueZxGD8LL2WojON78Mvnq7LdAMEtu2frrwld1fr3geixg3iiMBIc/LLAZpw==}
@@ -3898,6 +3936,12 @@ snapshots:
       - supports-color
       - typescript
 
+  '@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      leaflet: 1.9.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3994,11 +4038,17 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/leaflet@1.9.20':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/lodash@4.17.20': {}
 
@@ -4564,6 +4614,8 @@ snapshots:
   jsox@1.2.121: {}
 
   kleur@3.0.3: {}
+
+  leaflet@1.9.4: {}
 
   lexical@0.35.0: {}
 
@@ -5199,6 +5251,13 @@ snapshots:
       react: 19.1.0
 
   react-is@16.13.1: {}
+
+  react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@react-leaflet/core': 3.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      leaflet: 1.9.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-select@5.9.0(@types/react@19.1.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Closes #31

## Summary
Added an interactive OpenStreetMap to the designs/[id] page to show where photos/videos were taken.

## Changes
- Created reusable Map component using Leaflet and OpenStreetMap
- No API key required – uses free OpenStreetMap tiles
- Shows location marker with optional location name
- Only displays when GPS coordinates are available
- Dynamic import to avoid SSR issues

Generated with [Claude Code](https://claude.ai/code)