### PR TITLE
fix: remove duplicate Welcome Back text from login page

### DIFF
--- a/apps/www/src/app/(authenticated)/layout.tsx
+++ b/apps/www/src/app/(authenticated)/layout.tsx
@@ -15,12 +15,6 @@ export default async function AuthenticatedLayout({
       <div className="min-h-screen bg-gradient-to-br from-yellow-50 to-amber-50 flex items-center justify-center p-4">
         <div className="w-full max-w-md">
           <div className="bg-white shadow-xl rounded-2xl p-8">
-            <h1 className="text-3xl font-bold text-center mb-2 text-gray-900">
-              Welcome Back
-            </h1>
-            <p className="text-gray-600 text-center mb-8">
-              Sign in to continue
-            </p>
             <LoginForm />
           </div>
         </div>


### PR DESCRIPTION
Fixes #46

Removed duplicate "Welcome Back / Sign in to continue" text that was appearing twice on the login/signup page.

The text was duplicated in both the authenticated layout and the LoginForm component. Since the LoginForm component already handles conditional header text for both login and signup states, I removed the duplicate from the layout.

Generated with [Claude Code](https://claude.ai/code)